### PR TITLE
Fix false dpkg install alert when removing packages.

### DIFF
--- a/ossec-testing/tests/dpkg.ini
+++ b/ossec-testing/tests/dpkg.ini
@@ -1,8 +1,34 @@
 [dpkg log]
-log 1 pass = 2018-05-31 12:09:56 upgrade vlc-plugin-visualization:amd64 3.0.2-1+b1 3.0.3-1
-log 2 pass = 2018-05-11 09:41:49 conffile /etc/redis/redis.conf keep
+log 1 pass = 2018-05-11 09:41:49 conffile /etc/redis/redis.conf keep
 
 rule = 2900
 alert = 0
 decoder = windows-date-format
 
+[dpkg upgrade]
+log 1 pass = 2018-05-31 12:09:56 upgrade vlc-plugin-visualization:amd64 3.0.2-1+b1 3.0.3-1
+
+rule = 2902
+alert = 7
+decoder = windows-date-format
+
+[dpkg install]
+log 1 pass = 2018-08-02 00:03:36 install nano:amd64 2.5.3-2ubuntu2
+
+rule = 2902
+alert = 7
+decoder = windows-date-format
+
+[dpkg remove status installed false positive]
+log 1 fail = 2024-12-18 17:49:01 status installed ufw:all 0.36-6ubuntu1.1
+
+rule = 2902
+alert = 7
+decoder = windows-date-format
+
+[dpkg remove]
+log 1 pass = 2024-12-18 17:49:01 remove ufw:all 0.36-6ubuntu1.1 <none>
+
+rule = 2903
+alert = 7
+decoder = windows-date-format

--- a/rules.d/00-crs-syslog_rules.xml
+++ b/rules.d/00-crs-syslog_rules.xml
@@ -605,7 +605,7 @@
 
  <rule id="2902" level="7">
     <if_sid>2900</if_sid>
-    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} status installed</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} (install|upgrade|configure)</pcre2>
     <description>New dpkg (Debian Package) installed.</description>
     <group>config_changed,</group>
   </rule>


### PR DESCRIPTION
Keep in sync with ossec/ossec-hids#2141: rule 2902 in rules.d/00-crs-syslog_rules.xml now matches install, upgrade, and configure actions instead of "status installed". Add ossec-testing cases for install, upgrade, remove, and the removal false positive.

Assisted-By: Fable 5