### PR TITLE
Fix Postfix rule 3331 false positive on postscreen client ports.

### DIFF
--- a/decoders.d/50-crs-postfix_decoder.xml
+++ b/decoders.d/50-crs-postfix_decoder.xml
@@ -5,6 +5,7 @@
     <ce101@ce.metu.edu.tr>: Relay access denied; from=<kryonomm@yahoo.com>
     to=<e10445@jubiipost.dk> proto=SMTP helo=<SM01.net>
   - postfix/smtpd[27712]: NOQUEUE: reject: MAIL from localhost[127.0.0.1]: 452 Insufficient system storage
+  - postfix/postscreen[20656]: NOQUEUE: reject: RCPT from [2xx.61.xx.175]:45264: 550 5.7.1 Service unavailable
  -->
 
 <decoder name="postfix">
@@ -15,7 +16,7 @@
   <use_own_name>true</use_own_name>
   <parent>postfix</parent>
   <prematch_pcre2>^NOQUEUE: reject: \w{4} from </prematch_pcre2>
-  <pcre2 offset="after_prematch">\[(\S+)\]:\d+?: (\d+?) |\[(\S+)\]:(\d+?): |\[(\S+)\]: (\d+?) |\[(\S+)\]:(\d+?): </pcre2>
+  <pcre2 offset="after_prematch">\[(\S+)\]: (\d+?) |\[(\S+)\]:\d+?: (\d+?) </pcre2>
   <order>srcip,id</order>
 </decoder>
 

--- a/ossec-testing/tests/postfix.ini
+++ b/ossec-testing/tests/postfix.ini
@@ -12,3 +12,17 @@ rule = 3303
 alert = 5
 decoder = postfix-reject
 
+[insufficient disk space]
+log 1 pass = May  8 08:26:55 mail postfix/smtpd[27712]: NOQUEUE: reject: MAIL from localhost[127.0.0.1]: 452 Insufficient system storage
+
+rule = 3331
+alert = 10
+decoder = postfix-reject
+
+[postscreen client port not smtp 452 - issue 1489]
+log 1 pass = Aug  5 02:14:59 pmxpfx02 postfix/postscreen[20656]: NOQUEUE: reject: RCPT from [2xx.61.xx.175]:45264: 550 5.7.1 Service unavailable; client [2xx.61.xx.175] blocked using b.barracudacentral.org; from=<admin@example.net>, to=<localaddr@localhost.com>, proto=ESMTP, helo=<mail.example.net>
+
+rule = 3331
+alert = 0
+decoder = postfix-reject
+

--- a/rules.d/50-crs-postfix_rules.xml
+++ b/rules.d/50-crs-postfix_rules.xml
@@ -83,7 +83,7 @@
 
   <rule id="3331" level="10" ignore="120">
     <if_sid>3300</if_sid>
-    <id_pcre2>^452</id_pcre2>
+    <id_pcre2>^452$</id_pcre2>
     <description>Postfix insufficient disk space error.</description>
     <group>service_availability,</group>
   </rule>


### PR DESCRIPTION
Stop the postfix-reject decoder from capturing the client port as the SMTP id, and anchor rule 3331 to exact response code 452. Add logtest cases for the issue 1489 false positive and a true 452 alert.

Assisted-By: Fable 5