### PR TITLE
Replace dead Honeynet Project link in rule 40601.

### DIFF
--- a/rules.d/60-crs-attack_rules.xml
+++ b/rules.d/60-crs-attack_rules.xml
@@ -114,7 +114,7 @@
     <if_matched_group>connection_attempt</if_matched_group>
     <description>Network scan from same source ip.</description>
     <same_source_ip />
-    <info type="link">http://project.honeynet.org/papers/enemy2/</info>
+    <info type="link">https://web.archive.org/web/20000815211839/http://project.honeynet.org/papers/enemy2/</info>
   </rule>
 </group> <!-- SYSLOG,SCANS -->
 


### PR DESCRIPTION
The project.honeynet.org paper URL is gone; point at the Wayback Machine snapshot instead (ossec-hids#2111).