### PR TITLE
Add muhstik to blacklisted user-agent rule 31508.

### DIFF
--- a/ossec-testing/tests/web_appsec.ini
+++ b/ossec-testing/tests/web_appsec.ini
@@ -63,6 +63,7 @@ log 5 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "
 log 6 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "Nikto (X11)"
 log 7 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "w3af.sourceforge.net (X11)"
 log 8 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "MJ12bot/v (X11)"
+log 9 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "muhstik-scan"
 
 rule = 31508
 alert = 6

--- a/rules.d/60-crs-web_appsec_rules.xml
+++ b/rules.d/60-crs-web_appsec_rules.xml
@@ -87,7 +87,7 @@
   <!-- BAD/Annoying user agents -->
   <rule id="31508" level="6">
     <if_sid>31100</if_sid>
-    <pcre2> "ZmEu"| "libwww-perl/|"the beast"|"Morfeus|"ZmEu|"Nikto|"w3af\.sourceforge\.net|MJ12bot/v| Jorgee"|"Proxy Gear Pro|"DataCha0s</pcre2>
+    <pcre2> "ZmEu"| "libwww-perl/|"the beast"|"Morfeus|"ZmEu|"Nikto|"w3af\.sourceforge\.net|MJ12bot/v| Jorgee"|"Proxy Gear Pro|"DataCha0s|muhstik</pcre2>
     <description>Blacklisted user agent (known malicious user agent).</description>
   </rule>
 


### PR DESCRIPTION
Matches muhstik-scan and related probes (ossec-hids#1387).