### PR TITLE
Limit PHP CGI rule 31110 to .php and cgi-bin URLs.

### DIFF
--- a/ossec-testing/tests/web_rules.ini
+++ b/ossec-testing/tests/web_rules.ini
@@ -27,3 +27,11 @@ log 1 pass = 2015-03-11 22:01:59 1.2.3.4 GET /CFIDE/adminapi/customtags/l10n.cfm
 rule = 31104
 alert = 6
 decoder = web-accesslog-iis-default
+
+[PHP CGI-bin vulnerability attempt.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /index.php?-s HTTP/1.1" 200 181 "-" "Mozilla/5.0 (X11)"
+log 2 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /cgi-bin/php?-dallow_url_include=1 HTTP/1.1" 200 181 "-" "Mozilla/5.0 (X11)"
+log 3 fail = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /t_00/css/fonts/icomoon.ttf?-d8wcrs HTTP/1.1" 200 5720 "https://example.com/t_00/css/main.css" "Mozilla/5.0 (X11)"
+rule = 31110
+alert = 6
+decoder = web-accesslog

--- a/rules.d/50-crs-web_rules.xml
+++ b/rules.d/50-crs-web_rules.xml
@@ -79,7 +79,7 @@
 
   <rule id="31110" level="6">
     <if_sid>31100</if_sid>
-    <url_pcre2>\?-d|\?-s|\?-a|\?-b|\?-w</url_pcre2>
+    <url_pcre2>\.php\?-[dsabw]|/cgi-bin/[^\s?]*\?-[dsabw]</url_pcre2>
     <description>PHP CGI-bin vulnerability attempt.</description>
     <group>attack,</group>
   </rule>


### PR DESCRIPTION
Avoid false positives on static assets such as font query strings like icomoon.ttf?-d8wcrs (ossec-hids#1101).