### PR TITLE
Detect Postfix SMTP connect aborts and escalate by source IP.

### DIFF
--- a/decoders.d/50-crs-postfix_decoder.xml
+++ b/decoders.d/50-crs-postfix_decoder.xml
@@ -27,4 +27,15 @@
   <order>srcip</order>
 </decoder>
 
+<!-- Extract srcip from smtpd TLS/connect aborts, e.g.:
+  - postfix/smtpd[29322]: SSL_accept error from unknown[203.0.113.10]: lost connection
+  - postfix/smtpd[29322]: lost connection after CONNECT from unknown[203.0.113.10]
+ -->
+<decoder name="postfix-connect-abort">
+  <parent>postfix</parent>
+  <prematch_pcre2>^SSL_accept error from |^lost connection after \S+ from </prematch_pcre2>
+  <pcre2 offset="after_prematch">\[(\S+)\]</pcre2>
+  <order>srcip</order>
+</decoder>
+
 

--- a/ossec-testing/tests/postfix.ini
+++ b/ossec-testing/tests/postfix.ini
@@ -12,17 +12,15 @@ rule = 3303
 alert = 5
 decoder = postfix-reject
 
-[insufficient disk space]
-log 1 pass = May  8 08:26:55 mail postfix/smtpd[27712]: NOQUEUE: reject: MAIL from localhost[127.0.0.1]: 452 Insufficient system storage
 
-rule = 3331
-alert = 10
-decoder = postfix-reject
+[SMTP connection aborted by remote client (SSL_accept).]
+log 1 pass = Aug  4 12:00:01 mail postfix/smtpd[29322]: SSL_accept error from unknown[203.0.113.10]: lost connection
+rule = 3335
+alert = 3
+decoder = postfix
 
-[postscreen client port not smtp 452 - issue 1489]
-log 1 pass = Aug  5 02:14:59 pmxpfx02 postfix/postscreen[20656]: NOQUEUE: reject: RCPT from [2xx.61.xx.175]:45264: 550 5.7.1 Service unavailable; client [2xx.61.xx.175] blocked using b.barracudacentral.org; from=<admin@example.net>, to=<localaddr@localhost.com>, proto=ESMTP, helo=<mail.example.net>
-
-rule = 3331
-alert = 0
-decoder = postfix-reject
-
+[SMTP connection aborted by remote client (after CONNECT).]
+log 1 pass = Aug  4 12:00:01 mail postfix/smtpd[29322]: lost connection after CONNECT from unknown[203.0.113.10]
+rule = 3335
+alert = 3
+decoder = postfix

--- a/rules.d/50-crs-postfix_rules.xml
+++ b/rules.d/50-crs-postfix_rules.xml
@@ -101,6 +101,13 @@
     <group>service_availability,</group>
   </rule>
 
+  <rule id="3335" level="3">
+    <if_sid>3320</if_sid>
+    <pcre2>^SSL_accept error from |^lost connection after CONNECT from </pcre2>
+    <description>Postfix SMTP connection aborted by remote client.</description>
+    <group>spam,</group>
+  </rule>
+
   <rule id="3351" level="6" frequency="$POSTFIX_FREQ" timeframe="90">
     <if_matched_sid>3301</if_matched_sid>
     <same_source_ip />
@@ -153,6 +160,13 @@
     <same_source_ip />
     <description>Multiple SASL authentication failures.</description>
     <group>authentication_failures,</group>
+  </rule>
+
+  <rule id="3358" level="10" frequency="$POSTFIX_FREQ" timeframe="120" ignore="60">
+    <if_matched_sid>3335</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple Postfix SMTP connection aborts from same source.</description>
+    <group>multiple_spam,</group>
   </rule>
 
   <rule id="3390" level="0">


### PR DESCRIPTION
Add postfix-connect-abort decoder plus rules 3335/3358 for SSL_accept and lost-connection-after-CONNECT probes (ossec-hids#1897).