### PR TITLE
Match Snort [Drop] fast alerts in the snort decoder.

### DIFF
--- a/decoders.d/50-crs-snort_decoder.xml
+++ b/decoders.d/50-crs-snort_decoder.xml
@@ -14,6 +14,8 @@
   - [**] [1:1882:10] ATTACK-RESPONSES id check returned userid [**]
     [Classification: Potentially Bad Traffic] [Priority: 2]
     {UDP} 192.168.20.32 -> 192.168.20.2
+  - [Drop] [**] [1:10000002:0] cmd.exe test detected [**] [Priority: 0]
+    {TCP} 10.1.4.2:59244 -> 10.1.7.2:80
   -->
 
 <decoder name="snort">
@@ -22,7 +24,7 @@
 
 <decoder name="snort">
   <type>ids</type>
-  <prematch_pcre2>^\[\*\*\] \[\d+:\d+:\d+\] </prematch_pcre2>
+  <prematch_pcre2>^\[\*\*\] \[\d+:\d+:\d+\] |^\[Drop\] \[\*\*\] \[\d+:\d+:\d+\] </prematch_pcre2>
 </decoder>
 
 <decoder name="snort2">

--- a/ossec-testing/tests/snort.ini
+++ b/ossec-testing/tests/snort.ini
@@ -1,0 +1,11 @@
+[Snort alert fast format.]
+log 1 pass = 10/20-20:43:32.334621  [**] [1:10000001:0] /etc/passwd test detected [**] [Priority: 0] {TCP} 10.1.4.2:59240 -> 10.1.7.2:80
+rule = 20101
+alert = 6
+decoder = snort
+
+[Snort drop fast format.]
+log 1 pass = 10/20-20:43:39.741995  [Drop] [**] [1:10000002:0] cmd.exe test detected [**] [Priority: 0] {TCP} 10.1.4.2:59244 -> 10.1.7.2:80
+rule = 20101
+alert = 6
+decoder = snort


### PR DESCRIPTION
Parent prematch required [**] only, so drop-mode lines never reached snort2 field extraction (ossec-hids#1926).