### PR TITLE
Decode named client IPs with optional BIND @cookie prefix.

### DIFF
--- a/decoders.d/50-crs-named_decoder.xml
+++ b/decoders.d/50-crs-named_decoder.xml
@@ -3,6 +3,8 @@
   - Examples:
   -  valhalla named[7885]: client 192.168.1.231#1142: update 'hayaletgemi.edu/IN' denied
   - named[12637]: client 1.2.3.4#32769: query (cache) 'somedomain.com/MX/IN' denied
+  - Oct 26 00:00:53 valhalla named[43400]: client @0x7f2b78046e40 76.188.251.143#80 (sl): query (cache) 'sl/ANY/IN' denied
+  - Nov 25 13:27:03 tiny named[478]: client @0xb464d6a2d0 127.0.0.1#25298 (www.slashdot.org): query: www.slashdot.org IN A + (127.0.0.1)
   -  Oct 22 10:12:33 junction named[31687]: /etc/blocked.slave:9892: syntax error near ';'
   -  Oct 22 10:12:33 junction named[31687]: reloading configuration failed: unexpected token
  -->
@@ -12,8 +14,8 @@
 
 <decoder name="named-query">
   <parent>named</parent>
-  <prematch_pcre2>: query </prematch_pcre2>
-  <pcre2>client (\S+)#\d+[ ]*?\S*: </pcre2>
+  <prematch_pcre2>: query:? </prematch_pcre2>
+  <pcre2>client (?:@\S+ )?(\S+)#\d+[ ]*?\S*: </pcre2>
   <order>srcip,url</order>
 </decoder>
 
@@ -26,7 +28,7 @@
 <decoder name="named_client">
   <parent>named</parent>
   <prematch_pcre2>^client </prematch_pcre2>
-  <pcre2 offset="after_prematch">^(\S+)#</pcre2>
+  <pcre2 offset="after_prematch">^(?:@\S+ )?(\S+)#</pcre2>
   <order>srcip</order>
 </decoder>
 
@@ -42,5 +44,3 @@
   <pcre2>for master (\S+):(\d+) \S+ \(source (\S+)#d\+\)$</pcre2>
   <order>dstip,dstport,srcip</order>
 </decoder>
-
-

--- a/ossec-testing/tests/named.ini
+++ b/ossec-testing/tests/named.ini
@@ -1,11 +1,12 @@
 [Query cache denied]
 log 1 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.3#1036: query (cache) denied
-log 2 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.4#32769: query (cache) denied 
-log 3 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.3#1036: query (cache) denied 
-log 4 fail = Aug 29 15:33:13 ns3 name[464]: client 217.148.39.4#32769: query (cache) denied 
+log 2 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.4#32769: query (cache) denied
+log 3 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.3#1036: query (cache) denied
+log 4 fail = Aug 29 15:33:13 ns3 name[464]: client 217.148.39.4#32769: query (cache) denied
 log 5 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.3#1036: query (cache)
 log 6 pass = Mar 13 01:42:45 net19 named[6147]: client 31.150.218.239#6173 (odcdavcxkvin.games.yuanyou8.com): query (cache) 'odcdavcxkvin.games.yuanyou8.com/A/IN' denied
+log 7 pass = Oct 26 10:32:22 valhalla named[43400]: client @0x7f2b68014d40 173.27.216.50#80 (sl): query (cache) 'sl/ANY/IN' denied
 
-rule = 12108 
+rule = 12108
 alert = 5
-decoder = named 
+decoder = named


### PR DESCRIPTION
Sync named decoders with ossec-hids so Ubuntu-style client @0x… logs expose srcip (ossec-hids#1927).