### PR TITLE
Document netstat Recv-Q workaround for rule 533.

### DIFF
--- a/rules.d/50-crs-ossec_rules.xml
+++ b/rules.d/50-crs-ossec_rules.xml
@@ -143,6 +143,11 @@
     <description>Ignoring external medias.</description> 
   </rule>
 
+  <!-- Default install command strips Recv-Q/Send-Q via awk (see install.sh).
+       Existing configs still using raw netstat output will false-positive on
+       queue churn; update the localfile command to:
+       netstat -tan |grep LISTEN |egrep -v '(127.0.0.1| ::1)' | awk '{print $1,$4,$5,$6}' | sort
+  -->
   <rule id="533" level="7">
     <if_sid>530</if_sid>
     <pcre2>ossec: output: 'netstat -tan</pcre2>


### PR DESCRIPTION
Note the install-time awk strip for Recv-Q/Send-Q false positives (ossec-hids#495, #2063).