### PR TITLE
Ignore snap and loop df 100% disk alerts.

### DIFF
--- a/rules.d/50-crs-ossec_rules.xml
+++ b/rules.d/50-crs-ossec_rules.xml
@@ -139,8 +139,8 @@
 
  <rule id="532" level="0">
     <if_sid>531</if_sid>
-    <pcre2>cdrom|/media|usb|/mount|floppy|dvd</pcre2>
-    <description>Ignoring external medias.</description> 
+    <pcre2>cdrom|/media|usb|/mount|floppy|dvd|/dev/loop|/snap/</pcre2>
+    <description>Ignoring removable media and snap/loop filesystems.</description>
   </rule>
 
   <!-- Default install command strips Recv-Q/Send-Q via awk (see install.sh).


### PR DESCRIPTION
Extend rule 532 under 531 for /dev/loop and /snap mounts (#1418).