### PR TITLE
Stop treating MJ12bot as a malicious user agent.

### DIFF
--- a/rules.d/60-crs-web_appsec_rules.xml
+++ b/rules.d/60-crs-web_appsec_rules.xml
@@ -87,7 +87,7 @@
   <!-- BAD/Annoying user agents -->
   <rule id="31508" level="6">
     <if_sid>31100</if_sid>
-    <pcre2> "ZmEu"| "libwww-perl/|"the beast"|"Morfeus|"ZmEu|"Nikto|"w3af\.sourceforge\.net|MJ12bot/v| Jorgee"|"Proxy Gear Pro|"DataCha0s|muhstik</pcre2>
+    <pcre2> "ZmEu"| "libwww-perl/|"the beast"|"Morfeus|"ZmEu|"Nikto|"w3af\.sourceforge\.net| Jorgee"|"Proxy Gear Pro|"DataCha0s|muhstik</pcre2>
     <description>Blacklisted user agent (known malicious user agent).</description>
   </rule>
 


### PR DESCRIPTION
Remove MJ12bot/v from rule 31508 (#1317).