### PR TITLE
Tighten 40501 and stop postgres stealing cPanel logs.

### DIFF
--- a/decoders.d/50-crs-cpanel_decoder.xml
+++ b/decoders.d/50-crs-cpanel_decoder.xml
@@ -1,0 +1,51 @@
+<!-- cPanel / cpsrvd (login_log, session_log, access_log).
+  - Examples:
+  - [2016-11-18 09:32:19 +0000] info [cpsrvd] 10.1.5.19 - admin "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN whostmgrd: user password hash is missing from system (user probably does not exist)
+  - [2017-01-25 06:01:10 -0500] info [cpsrvd] 10.1.5.19 - test "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN cpaneld: invalid cpanel user test (loadcpdata failed)
+  - [2016-04-18 13:07:02 -0400] info [cpsrvd] 10.1.5.19 - root - SUCCESS LOGIN whostmgrd
+  - [2016-04-18 13:07:15 -0400] info [cpsrvd] 10.1.5.19 - reseller (possessor: root) - SUCCESS LOGIN cpaneld
+  - [2017-02-03 01:21:31 -0500] info [cpsrvd] 10.101.1.18 NEW testuser:XImQi9d3anWMNSc9 address=10.101.1.18,app=cpaneld,creator=pupkin,method=handle_form_login,path=form,possessed=0
+  - [2017-01-25 06:15:38 -0500] info [cpsrvd] 10.1.5.19 PURGE root:Nmm4xzhSpA2Sddv3 logout
+  - 46.118.10.79 - paul [11/18/2016:09:35:43 -0000] "GET" FAILED LOGIN cpdavd: Could not fetch system home directory for paul
+  -->
+<decoder name="cpanel">
+  <prematch_pcre2>^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [+-]\d{4}\] info \[cpsrvd\] </prematch_pcre2>
+</decoder>
+
+<decoder name="cpanel-login-failed">
+  <parent>cpanel</parent>
+  <use_own_name>true</use_own_name>
+  <prematch_pcre2 offset="after_parent">FAILED LOGIN</prematch_pcre2>
+  <pcre2 offset="after_parent">^(\S+) - (\S+)</pcre2>
+  <order>srcip,user</order>
+</decoder>
+
+<decoder name="cpanel-login-success">
+  <parent>cpanel</parent>
+  <use_own_name>true</use_own_name>
+  <prematch_pcre2 offset="after_parent">SUCCESS LOGIN</prematch_pcre2>
+  <pcre2 offset="after_parent">^(\S+) - (.+?) - SUCCESS LOGIN</pcre2>
+  <order>srcip,user</order>
+</decoder>
+
+<decoder name="cpanel-session-new">
+  <parent>cpanel</parent>
+  <use_own_name>true</use_own_name>
+  <prematch_pcre2 offset="after_parent"> NEW </prematch_pcre2>
+  <pcre2 offset="after_parent">^(\S+) NEW (\w+):</pcre2>
+  <order>srcip,user</order>
+</decoder>
+
+<decoder name="cpanel-session-logout">
+  <parent>cpanel</parent>
+  <use_own_name>true</use_own_name>
+  <prematch_pcre2 offset="after_parent"> PURGE .+ logout</prematch_pcre2>
+  <pcre2 offset="after_parent">^(\S+) PURGE (\w+):</pcre2>
+  <order>srcip,user</order>
+</decoder>
+
+<decoder name="cpanel-access-failed">
+  <prematch_pcre2>^\S+ \S+ \S+ \[\d+/\d+/\d+:\d+:\d+:\d+ [+-]\d+\] "\w+" FAILED LOGIN</prematch_pcre2>
+  <pcre2>^(\S+) \S+ (\S+)</pcre2>
+  <order>srcip,user</order>
+</decoder>

--- a/decoders.d/50-crs-openbsd_decoder.xml
+++ b/decoders.d/50-crs-openbsd_decoder.xml
@@ -68,7 +68,7 @@
 
 <!-- OpenBSD httpd -->
 <decoder name="openbsd-httpd">
-  <prematch_pcre2> \[\d+/[A-Za-z0-9@_-]+/\d+:\d+:\d+:\d+ -\d+\] "</prematch_pcre2>
+  <prematch_pcre2> \[\d+/[A-Za-z]+/\d+:\d+:\d+:\d+ -\d+\] "</prematch_pcre2>
   <pcre2>^(\S+) (\S+) \S+ \S+ \[\d+/[A-Za-z0-9@_-]+/\d+:\d+:\d+:\d+ -\d+\] "(\S+) (\S+) HTTP/\d\.\d" (\d+?) \d$</pcre2>
   <order>url, srcip, protocol, url, status</order>
   <type>web-log</type>

--- a/decoders.d/50-crs-postgresql_decoder.xml
+++ b/decoders.d/50-crs-postgresql_decoder.xml
@@ -2,10 +2,10 @@
        - Examples:
   - [2007-08-31 18:37:09.454 ADT] 192.168.2.99: LOG:  connection authorized: user=ossec_user database=ossecdb
   - [2007-08-31 18:37:15.525 ADT] 192.168.2.99: ERROR:  relation "alert2" does not exist
+  - Timezone token must start with a letter so cPanel numeric offsets (+/-0400) are not stolen.
   -->
 <decoder name="postgresql_log">
-  <prematch_pcre2>^\[\d{4}-\d{2}-\d{2} \S+ [A-Za-z0-9@_-]+?\] </prematch_pcre2>
+  <prematch_pcre2>^\[\d{4}-\d{2}-\d{2} \S+ [A-Za-z][A-Za-z0-9@_+-]*\] </prematch_pcre2>
   <pcre2 offset="after_prematch">^\S+ ([A-Za-z0-9@_-]+?): </pcre2>
   <order>status</order>
 </decoder>
-

--- a/ossec-testing/tests/cpanel.ini
+++ b/ossec-testing/tests/cpanel.ini
@@ -1,38 +1,51 @@
 [successful login]
-log 1 fail = [2016-04-18 13:07:02 -0400] info [cpsrvd] 10.1.5.19 - root - SUCCESS LOGIN whostmgrd
-log 2 fail = [2016-04-18 13:07:15 -0400] info [cpsrvd] 10.1.5.19 - reseller (possessor: root) - SUCCESS LOGIN cpaneld
-log 3 fail = [2016-04-18 13:08:27 -0400] info [cpsrvd] 10.1.5.19 - emailaccount@reseller.com (possessor: reseller) - SUCCESS LOGIN webmaild
+log 1 pass = [2016-04-18 13:07:02 -0400] info [cpsrvd] 10.1.5.19 - root - SUCCESS LOGIN whostmgrd
+log 2 pass = [2016-04-18 13:07:15 -0400] info [cpsrvd] 10.1.5.19 - reseller (possessor: root) - SUCCESS LOGIN cpaneld
+log 3 pass = [2016-04-18 13:08:27 -0400] info [cpsrvd] 10.1.5.19 - emailaccount@reseller.com (possessor: reseller) - SUCCESS LOGIN webmaild
 
-rule = 11007
+rule = 11002
 alert = 3
-decoder = postgresql_log
+decoder = cpanel-login-success
 
 
 [cpanel attacks]
-log 1 fail = [2017-01-25 06:01:10 -0500] info [cpsrvd] 10.1.5.19 - test "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN cpaneld: invalid cpanel user test (loadcpdata failed)
-
-rule = 11001
-alert = 5
-decoder = postgresql_log
-
-[cpanel attacks 2]
-log 1 fail = [2016-11-18 09:32:19 +0000] info [cpsrvd] 10.1.5.19 - admin "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN whostmgrd: user password hash is missing from system (user probably does not exist)
+log 1 pass = [2017-01-25 06:01:10 -0500] info [cpsrvd] 10.1.5.19 - test "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN cpaneld: invalid cpanel user test (loadcpdata failed)
 
 rule = 11000
 alert = 5
-decoder = cpanel-login
+decoder = cpanel-login-failed
+
+[cpanel attacks 2]
+log 1 pass = [2016-11-18 09:32:19 +0000] info [cpsrvd] 10.1.5.19 - admin "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN whostmgrd: user password hash is missing from system (user probably does not exist)
+
+rule = 11000
+alert = 5
+decoder = cpanel-login-failed
 
 [successful login 2]
-log 1 fail = [2016-04-18 13:07:02 +0400] info [cpsrvd] 10.1.5.19 - root - SUCCESS LOGIN whostmgrd
+log 1 pass = [2016-04-18 13:07:02 +0400] info [cpsrvd] 10.1.5.19 - root - SUCCESS LOGIN whostmgrd
 
-rule = 11006
+rule = 11002
 alert = 3
-decoder = cpanel-login
+decoder = cpanel-login-success
+
+[session new]
+log 1 pass = [2017-02-03 01:21:31 -0500] info [cpsrvd] 10.101.1.18 NEW testuser:XImQi9d3anWMNSc9 address=10.101.1.18,app=cpaneld,creator=pupkin,method=handle_form_login,path=form,possessed=0
+
+rule = 11003
+alert = 3
+decoder = cpanel-session-new
 
 [session purge]
-log 1 fail = [2017-01-25 06:15:38 -0500] info [cpsrvd] 10.1.5.19 PURGE root:Nmm4xzhSpA2Sddv3 logout
+log 1 pass = [2017-01-25 06:15:38 -0500] info [cpsrvd] 10.1.5.19 PURGE root:Nmm4xzhSpA2Sddv3 logout
 
-rule = 11009
+rule = 11004
 alert = 3
-decoder = postgresql_log
+decoder = cpanel-session-logout
 
+[cpanel access failed]
+log 1 pass = 46.118.10.79 - paul [11/18/2016:09:35:43 -0000] "GET" FAILED LOGIN cpdavd: Could not fetch system home directory for paul
+
+rule = 11005
+alert = 5
+decoder = cpanel-access-failed

--- a/rules.d/50-crs-cpanel_rules.xml
+++ b/rules.d/50-crs-cpanel_rules.xml
@@ -1,0 +1,61 @@
+<!--
+  -  Official cPanel rules for OSSEC.
+  -
+  -  Authors: Alexandr Garaga (@alex-front), Paul Klymenko
+  -
+  -  This program is a free software; you can redistribute it
+  -  and/or modify it under the terms of the GNU General Public
+  -  License (version 2) as published by the FSF - Free Software
+  -  Foundation.
+  -
+  -  License details: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+  -->
+
+<group name="syslog,cpanel,">
+
+  <rule id="11000" level="5">
+    <if_sid>2501</if_sid>
+    <decoded_as>cpanel-login-failed</decoded_as>
+    <description>cPanel authentication failure.</description>
+    <group>authentication_failed,</group>
+  </rule>
+
+  <rule id="11001" level="10" frequency="4" timeframe="360">
+    <if_matched_sid>11000</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple cPanel authentication failures.</description>
+    <group>authentication_failures,</group>
+  </rule>
+
+  <rule id="11002" level="3">
+    <decoded_as>cpanel-login-success</decoded_as>
+    <description>cPanel authentication success.</description>
+    <group>authentication_success,</group>
+  </rule>
+
+  <rule id="11003" level="3">
+    <decoded_as>cpanel-session-new</decoded_as>
+    <description>cPanel session created.</description>
+    <group>authentication_success,</group>
+  </rule>
+
+  <rule id="11004" level="3">
+    <decoded_as>cpanel-session-logout</decoded_as>
+    <description>cPanel session logout.</description>
+  </rule>
+
+  <rule id="11005" level="5">
+    <if_sid>2501</if_sid>
+    <decoded_as>cpanel-access-failed</decoded_as>
+    <description>cPanel access_log authentication failure.</description>
+    <group>authentication_failed,</group>
+  </rule>
+
+  <rule id="11006" level="10" frequency="4" timeframe="360">
+    <if_matched_sid>11005</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple cPanel access_log authentication failures.</description>
+    <group>authentication_failures,</group>
+  </rule>
+
+</group>

--- a/rules.d/60-crs-attack_rules.xml
+++ b/rules.d/60-crs-attack_rules.xml
@@ -98,9 +98,12 @@
 
 <!-- Privilege escalation messages -->
 <group name="syslog,elevation_of_privilege,">
-  <rule id="40501" level="15" timeframe="300" frequency="2">
+  <!-- Require several prior attack-group hits on the same host so routine
+       admin SSH + useradd (and residual scanner noise) do not fire level 15. -->
+  <rule id="40501" level="15" timeframe="300" frequency="4">
     <if_group>adduser</if_group>
     <if_matched_group>attacks</if_matched_group>
+    <same_location />
     <description>Attacks followed by the addition </description>
     <description>of an user.</description>
   </rule>


### PR DESCRIPTION
Raise rule 40501 frequency with same_location (#1082). Narrow postgresql_log/openbsd-httpd prematches and add cPanel decoders/rules so cpsrvd events decode correctly (#1132).