### PR TITLE
Fix web-accesslog spaces and POST ignore shadowing.

### DIFF
--- a/decoders.d/50-crs-web-accesslog_decoder.xml
+++ b/decoders.d/50-crs-web-accesslog_decoder.xml
@@ -11,12 +11,14 @@
   -  1.1.1.1 - username [18/Jan/2006:13:10:06 -0500] "GET /xxx.html HTTP/1.1"
   -  123.4.5.6 aa.xx.com - [05/Nov/2006:00:46:56 -0500] "GET / HTTP/1.1" 302 -
   - ::ffff:202.194.15.192 190.7.138.180 - [18/Oct/2010:10:48:55 -0500] "GET //php-my-admin/config/config.inc.php?p=phpinfo(); HTTP/1.1" 404 345 "-"  "Mozilla/4.0 (compatible; MSIE 6.0; Windows 98)"
+  - 11.22.33.44 - - [01/Aug/2016:05:15:07 +0000] "GET /ariadne/www/loader.php/system/\x22><iMg src=N onerror=alert(document.cookie)> HTTP/1.1" 301 178 "-" "Mozilla/5.0 [en] (X11, U; OpenVAS 8.0.7)"
+  - URL may contain spaces (scanner/XSS payloads); use .+? instead of \S+ (#914).
   -->
 <decoder name="web-accesslog">
   <type>web-log</type>
-  <prematch_pcre2>^\S+ \S+ \S+ \[\S+ \S\d+\] "\w+ \S+ HTTP\S+" </prematch_pcre2>
+  <prematch_pcre2>^\S+ \S+ \S+ \[\S+ \S\d+\] "\w+ .+? HTTP\S+" </prematch_pcre2>
   <pcre2>^(\S+) \S+ (\S+) \[\S+ \S\d+\] </pcre2>
-  <pcre2>"(\w+) (\S+) HTTP\S+" (\d+) </pcre2>
+  <pcre2>"(\w+) (.+?) HTTP\S+" (\d+) </pcre2>
   <order>srcip, srcuser, action, url, id</order>
 </decoder>
 

--- a/ossec-testing/tests/web_appsec.ini
+++ b/ossec-testing/tests/web_appsec.ini
@@ -133,7 +133,8 @@ alert = 6
 decoder = web-accesslog
 
 [POST request received.]
-log 1 fail = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST / HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST / HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+log 2 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST /api/v1/submit HTTP/1.1" 200 181 "-" "Mozilla/5.0 (X11)"
 
 rule = 31530
 alert = 3

--- a/ossec-testing/tests/web_rules.ini
+++ b/ossec-testing/tests/web_rules.ini
@@ -35,3 +35,9 @@ log 3 fail = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /t_00/css/fonts/icomo
 rule = 31110
 alert = 6
 decoder = web-accesslog
+
+[Web accesslog URL with spaces (scanner XSS).]
+log 1 pass = 11.22.33.44 - - [01/Aug/2016:05:15:07 +0000] "GET /ariadne/www/loader.php/system/\x22><iMg src=N onerror=alert(document.cookie)> HTTP/1.1" 301 178 "-" "Mozilla/5.0 [en] (X11, U; OpenVAS 8.0.7)"
+rule = 31108
+alert = 0
+decoder = web-accesslog

--- a/rules.d/60-crs-web_appsec_rules.xml
+++ b/rules.d/60-crs-web_appsec_rules.xml
@@ -91,9 +91,10 @@
     <description>Blacklisted user agent (known malicious user agent).</description>
   </rule>
 
-  <!-- WordPress wp-login.php brute force -->
+  <!-- WordPress wp-login.php brute force.
+       Parent is 31100 (not 31108): POSTs are no longer "simple" (#922). -->
   <rule id="31509" level="3">
-    <if_sid>31108</if_sid>
+    <if_sid>31100</if_sid>
     <url_pcre2>wp-login\.php|/administrator</url_pcre2>
     <pcre2>\] "POST \S+wp-login\.php| "POST /administrator</pcre2>
     <description>CMS (WordPress or Joomla) login attempt.</description>


### PR DESCRIPTION
Allow spaces in request URLs (#914). Parent CMS login 31509 on 31100 so POST flood/appsec rules are not shadowed by simple-request ignore (#922).