### PR TITLE
Add Asterisk IPv6 denied decoder without square brackets.

### DIFF
--- a/decoders.d/50-crs-asterisk_decoder.xml
+++ b/decoders.d/50-crs-asterisk_decoder.xml
@@ -30,6 +30,13 @@
   <order>srcip,srcport</order>
 </decoder>
 
+<decoder name="asterisk-denied3-ipv6">
+  <parent>asterisk</parent>
+  <prematch_pcre2>^NOTICE\[\d+?\]\[[A-Za-z0-9@_-]+?\]: \S+ in \S+: Call from </prematch_pcre2>
+  <pcre2 offset="after_prematch">^'\S*' \(\[([^\]]+)\]:(\d+)\) to extension '(\S+)' rejected because extension not found in context '(\S+)'\.$</pcre2>
+  <order>srcip, srcport, extra_data, extra_data</order>
+</decoder>
+
 <decoder name="asterisk-denied3">
   <parent>asterisk</parent>
   <prematch_pcre2>^NOTICE\[\d+?\]\[[A-Za-z0-9@_-]+?\]: \S+ in \S+: Call from </prematch_pcre2>


### PR DESCRIPTION
Capture bracketed IPv6 call-from addresses as bare srcip so active response can block them; leave the existing IPv4 decoder unchanged (#1892).